### PR TITLE
TLA-12: Add support to delete items in category screen

### DIFF
--- a/TodoListApp.xcodeproj/project.pbxproj
+++ b/TodoListApp.xcodeproj/project.pbxproj
@@ -15,10 +15,12 @@
 		7C1E62202AE6C23400978667 /* TodoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1E621F2AE6C23400978667 /* TodoListViewController.swift */; };
 		7C1E62232AE6DBBE00978667 /* LocalDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1E62222AE6DBBE00978667 /* LocalDataService.swift */; };
 		7C1E62282AE6E08E00978667 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C1E62272AE6E08E00978667 /* UIColor+.swift */; };
+		7C360A4F2B5D15BF008EAFD0 /* CategoryListDataHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C360A4E2B5D15BF008EAFD0 /* CategoryListDataHandler.swift */; };
 		7C4C75A22B302E8500A59794 /* TodoListItemViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4C75A12B302E8500A59794 /* TodoListItemViewData.swift */; };
-		7C676C092B39BFEF00E10959 /* LocalDataHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C676C082B39BFEF00E10959 /* LocalDataHandler.swift */; };
+		7C676C092B39BFEF00E10959 /* TodoListDataHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C676C082B39BFEF00E10959 /* TodoListDataHandler.swift */; };
 		7C676C0B2B39C11C00E10959 /* ViewDataTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C676C0A2B39C11C00E10959 /* ViewDataTransformer.swift */; };
 		7CA6E50A2B135CE500A2842A /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA6E5092B135CE500A2842A /* BaseViewController.swift */; };
+		7CAA5E812B4C481A007041C4 /* CategoryListItemViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA5E802B4C481A007041C4 /* CategoryListItemViewData.swift */; };
 		7CD0F0F02AEC3725005F0AA7 /* TodoListUserInputContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD0F0EF2AEC3725005F0AA7 /* TodoListUserInputContainerView.swift */; };
 		7CF6067D2AF16CA2001E809A /* CategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF6067C2AF16CA2001E809A /* CategoryListViewController.swift */; };
 /* End PBXBuildFile section */
@@ -34,10 +36,12 @@
 		7C1E621F2AE6C23400978667 /* TodoListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListViewController.swift; sourceTree = "<group>"; };
 		7C1E62222AE6DBBE00978667 /* LocalDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataService.swift; sourceTree = "<group>"; };
 		7C1E62272AE6E08E00978667 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
+		7C360A4E2B5D15BF008EAFD0 /* CategoryListDataHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListDataHandler.swift; sourceTree = "<group>"; };
 		7C4C75A12B302E8500A59794 /* TodoListItemViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListItemViewData.swift; sourceTree = "<group>"; };
-		7C676C082B39BFEF00E10959 /* LocalDataHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataHandler.swift; sourceTree = "<group>"; };
+		7C676C082B39BFEF00E10959 /* TodoListDataHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListDataHandler.swift; sourceTree = "<group>"; };
 		7C676C0A2B39C11C00E10959 /* ViewDataTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDataTransformer.swift; sourceTree = "<group>"; };
 		7CA6E5092B135CE500A2842A /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		7CAA5E802B4C481A007041C4 /* CategoryListItemViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListItemViewData.swift; sourceTree = "<group>"; };
 		7CD0F0EF2AEC3725005F0AA7 /* TodoListUserInputContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListUserInputContainerView.swift; sourceTree = "<group>"; };
 		7CF6067C2AF16CA2001E809A /* CategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryListViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -109,7 +113,8 @@
 			isa = PBXGroup;
 			children = (
 				7C1E62222AE6DBBE00978667 /* LocalDataService.swift */,
-				7C676C082B39BFEF00E10959 /* LocalDataHandler.swift */,
+				7C676C082B39BFEF00E10959 /* TodoListDataHandler.swift */,
+				7C360A4E2B5D15BF008EAFD0 /* CategoryListDataHandler.swift */,
 			);
 			path = DatabaseService;
 			sourceTree = "<group>";
@@ -127,6 +132,7 @@
 			children = (
 				7C4C75A12B302E8500A59794 /* TodoListItemViewData.swift */,
 				7C676C0A2B39C11C00E10959 /* ViewDataTransformer.swift */,
+				7CAA5E802B4C481A007041C4 /* CategoryListItemViewData.swift */,
 			);
 			path = ViewData;
 			sourceTree = "<group>";
@@ -211,9 +217,11 @@
 			files = (
 				7CF6067D2AF16CA2001E809A /* CategoryListViewController.swift in Sources */,
 				7CD0F0F02AEC3725005F0AA7 /* TodoListUserInputContainerView.swift in Sources */,
+				7C360A4F2B5D15BF008EAFD0 /* CategoryListDataHandler.swift in Sources */,
 				7C1E62202AE6C23400978667 /* TodoListViewController.swift in Sources */,
 				7C1E62082AE6B9DF00978667 /* AppDelegate.swift in Sources */,
-				7C676C092B39BFEF00E10959 /* LocalDataHandler.swift in Sources */,
+				7C676C092B39BFEF00E10959 /* TodoListDataHandler.swift in Sources */,
+				7CAA5E812B4C481A007041C4 /* CategoryListItemViewData.swift in Sources */,
 				7C1E620A2AE6B9DF00978667 /* SceneDelegate.swift in Sources */,
 				7CA6E50A2B135CE500A2842A /* BaseViewController.swift in Sources */,
 				7C0D44672AEE6A170027497D /* TodoListModel.xcdatamodeld in Sources */,

--- a/TodoListApp/DatabaseService/CategoryListDataHandler.swift
+++ b/TodoListApp/DatabaseService/CategoryListDataHandler.swift
@@ -1,0 +1,50 @@
+//
+//  CategoryListDataHandler.swift
+//  TodoListApp
+//
+//  Created by Pranav Patil on 21/01/24.
+//
+
+import Foundation
+
+class CategoryListDataHandler {
+
+    private var categoryListItemModels = [CategoryListItemModel]()
+
+    func saveCategoryListItem(viewData: CategoryListItemViewData) -> Bool {
+        guard let name = viewData.name else {
+            assertionFailure("Name of the category cannot be nil")
+            return false
+        }
+
+        for model in categoryListItemModels {
+            if model.name == name {
+                // TODO: Add support to display popup for "Item already exists"
+                return false
+            }
+        }
+
+        let newItem = LocalDataService.createCategoryListItemModel(name: name)
+        categoryListItemModels.append(newItem)
+        LocalDataService.saveContextData()
+        return true
+    }
+
+    func fetchCategoryData() -> [CategoryListItemViewData] {
+        categoryListItemModels = LocalDataService.fetchCategoryData()
+        return ViewDataTransformer.getCategoryListItemViewDatas(from: categoryListItemModels)
+    }
+
+    func deleteCategoryListItems(viewDatas: [CategoryListItemViewData]) {
+        var itemsToDelete = [CategoryListItemModel]()
+        viewDatas.forEach { viewData in
+            let item = categoryListItemModels.filter { model in
+                return model.name == viewData.name
+            }
+            itemsToDelete.append(contentsOf: item)
+        }
+
+        LocalDataService.deleteCategoryItems(items: itemsToDelete)
+    }
+
+}

--- a/TodoListApp/DatabaseService/LocalDataService.swift
+++ b/TodoListApp/DatabaseService/LocalDataService.swift
@@ -32,14 +32,24 @@ class LocalDataService {
         return categoryListItemModel
     }
 
-    static func fetchCategoryData() -> [CategoryListItemModel] {
+    static func fetchCategoryData(for categoryName: String? = nil) -> [CategoryListItemModel] {
         let request: NSFetchRequest<CategoryListItemModel> = CategoryListItemModel.fetchRequest()
+
+        if let categoryName {
+            request.predicate = NSPredicate(format: "name == %@", argumentArray: [categoryName])
+        }
+
         do {
             return try context.fetch(request)
         } catch {
             print("Error fetching CategoryListItemModel data, error = \(error)")
             return []
         }
+    }
+
+    static func deleteCategoryItems(items: [CategoryListItemModel]) {
+        items.forEach { context.delete($0) }
+        saveContextData()
     }
 
     // MARK: - TODO list
@@ -54,8 +64,8 @@ class LocalDataService {
         return todoListItemModel
     }
 
-    static func fetchTodoListData(category: CategoryListItemModel?) -> [TodoListItemModel] {
-        guard let categoryName = category?.name else {
+    static func fetchTodoListData(categoryName: String?) -> [TodoListItemModel] {
+        guard let categoryName else {
             assertionFailure("Category name cannot be nil")
             return []
         }

--- a/TodoListApp/DatabaseService/TodoListDataHandler.swift
+++ b/TodoListApp/DatabaseService/TodoListDataHandler.swift
@@ -7,23 +7,24 @@
 
 import Foundation
 
-class LocalDataHandler {
+class TodoListDataHandler {
 
     private var todoListItemModels = [TodoListItemModel]()
 
-    func fetchTodoListData(category: CategoryListItemModel?) -> [TodoListItemViewData] {
-        todoListItemModels = LocalDataService.fetchTodoListData(category: category)
+    func fetchTodoListData(category: CategoryListItemViewData?) -> [TodoListItemViewData] {
+        todoListItemModels = LocalDataService.fetchTodoListData(categoryName: category?.name)
         return ViewDataTransformer.getTodoListItemViewDatas(from: todoListItemModels)
     }
 
     func saveTodoListItem(viewData: TodoListItemViewData) -> Bool {
-        guard let title = viewData.title, let category = viewData.parentCategory else {
+        let category = LocalDataService.fetchCategoryData(for: viewData.parentCategory?.name).first
+        guard let title = viewData.title, let category else {
             assertionFailure("Title and Category cannot be nil")
             return false
         }
 
         for model in todoListItemModels {
-            if model.title == title, model.parentCategory == category {
+            if model.title == title, model.parentCategory?.name == category.name {
                 // TODO: Add support to display popup for "Item already exists"
                 return false
             }
@@ -45,7 +46,7 @@ class LocalDataHandler {
         }
 
         for model in todoListItemModels {
-            if model.title == title, model.parentCategory == category {
+            if model.title == title, model.parentCategory?.name == category.name {
                 model.isCompleted = viewData.isCompleted
                 LocalDataService.saveContextData()
                 return
@@ -57,11 +58,10 @@ class LocalDataHandler {
         var itemsToDelete = [TodoListItemModel]()
         viewDatas.forEach { viewData in
             let item = todoListItemModels.filter { model in
-                return model.title == viewData.title && model.parentCategory == viewData.parentCategory
+                return model.title == viewData.title && model.parentCategory?.name == viewData.parentCategory?.name
             }
             itemsToDelete.append(contentsOf: item)
         }
-
 
         LocalDataService.deleteItems(items: itemsToDelete)
     }

--- a/TodoListApp/TodoList/ViewController/BaseViewController.swift
+++ b/TodoListApp/TodoList/ViewController/BaseViewController.swift
@@ -10,6 +10,7 @@ class BaseViewController: UIViewController {
     // MARK: - Properties
 
     var isBulkDeleteEnabled = false
+
     private var tableViewBottomWithDeleteContainer: NSLayoutConstraint?
     private var tableViewBottomWithViewController: NSLayoutConstraint?
 
@@ -20,6 +21,7 @@ class BaseViewController: UIViewController {
     }()
 
     private let deleteButtonContainerView = UIView()
+
     private lazy var seperator: UIView = {
         let view = UIView()
         view.heightAnchor.constraint(equalToConstant: 0.5).isActive = true

--- a/TodoListApp/TodoList/ViewController/CategoryListViewController.swift
+++ b/TodoListApp/TodoList/ViewController/CategoryListViewController.swift
@@ -4,7 +4,8 @@ class CategoryListViewController: BaseViewController {
 
     // MARK: - Properties
 
-    private var categoryList = [CategoryListItemModel]()
+    private var categoryListViewDatas = [CategoryListItemViewData]()
+    private lazy var localDataHandler = CategoryListDataHandler()
 
     // MARK: - Inits
 
@@ -15,7 +16,7 @@ class CategoryListViewController: BaseViewController {
         tableView.dataSource = self
         tableView.delegate = self
 
-        categoryList = LocalDataService.fetchCategoryData()
+        categoryListViewDatas = localDataHandler.fetchCategoryData()
 
         navigationItem.title = "Categories"
     }
@@ -43,15 +44,28 @@ class CategoryListViewController: BaseViewController {
         alert.addAction(UIAlertAction(title: "Add", style: UIAlertAction.Style.default, handler: { _ in
             if let textfieldText = alert.textFields?.first?.text,
                !textfieldText.replacingOccurrences(of: " ", with: "").isEmpty {
-                let newItem = LocalDataService.createCategoryListItemModel(name: textfieldText)
-                self.categoryList.append(newItem)
-                LocalDataService.saveContextData()
-                self.tableView.reloadData()
+                let newItem = CategoryListItemViewData(name: textfieldText)
+                if self.localDataHandler.saveCategoryListItem(viewData: newItem) {
+                    self.categoryListViewDatas.append(newItem)
+                    self.tableView.reloadData()
+                }
             }
         }))
 
         // Show the alert
         present(alert, animated: true, completion: nil)
+    }
+
+    override func exitBulkDelete() {
+        super.exitBulkDelete()
+        navigationItem.title = "Categories"
+    }
+
+    override func deleteSelectedItems() {
+        let itemsToDelete = categoryListViewDatas.filter { $0.shouldDelete }
+        categoryListViewDatas.removeAll { $0.shouldDelete }
+        localDataHandler.deleteCategoryListItems(viewDatas: itemsToDelete)
+        exitBulkDelete()
     }
 
 }
@@ -61,19 +75,29 @@ class CategoryListViewController: BaseViewController {
 extension CategoryListViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return categoryList.count
+        return categoryListViewDatas.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell()
-        cell.textLabel?.text = categoryList[indexPath.row].name
-        cell.accessoryType = .disclosureIndicator
+        cell.textLabel?.text = categoryListViewDatas[indexPath.row].name
+        cell.accessoryType = isBulkDeleteEnabled ? .none : .disclosureIndicator
+        cell.imageView?.image = isBulkDeleteEnabled ? UIImage(systemName: "square") : nil
         cell.selectionStyle = .none
         return cell
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let vc = TodoListViewController(category: categoryList[indexPath.row])
+        let currentSelectedCategory = categoryListViewDatas[indexPath.row]
+        if isBulkDeleteEnabled, let cell = tableView.cellForRow(at: indexPath) {
+            let shouldDelete = currentSelectedCategory.shouldDelete
+            cell.imageView?.image = shouldDelete
+            ? UIImage(systemName: "square")
+            : UIImage(systemName: "checkmark.square.fill")
+            currentSelectedCategory.shouldDelete = !shouldDelete
+            return
+        }
+        let vc = TodoListViewController(category: currentSelectedCategory)
         navigationController?.pushViewController(vc, animated: true)
     }
 

--- a/TodoListApp/TodoList/ViewController/TodoListViewController.swift
+++ b/TodoListApp/TodoList/ViewController/TodoListViewController.swift
@@ -12,7 +12,7 @@ class TodoListViewController: BaseViewController {
 
     // MARK: - Private properties
 
-    private var category: CategoryListItemModel?
+    private var category: CategoryListItemViewData?
     private var todoListData = [TodoListItemViewData]()
     private var isKeyboardVisible = false
     private var userInputContainerViewBottomConstraint: NSLayoutConstraint?
@@ -26,11 +26,11 @@ class TodoListViewController: BaseViewController {
         return containerView
     }()
 
-    private lazy var localDataHandler = LocalDataHandler()
+    private lazy var localDataHandler = TodoListDataHandler()
 
     // MARK: - Inits
 
-    init(category: CategoryListItemModel) {
+    init(category: CategoryListItemViewData) {
         super.init()
 
         setupUserInputContainerView()
@@ -54,8 +54,6 @@ class TodoListViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        print("####### path = \(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask))")
 
         // Keyboard observer
         NotificationCenter.default.addObserver(

--- a/TodoListApp/TodoList/ViewData/CategoryListItemViewData.swift
+++ b/TodoListApp/TodoList/ViewData/CategoryListItemViewData.swift
@@ -1,0 +1,20 @@
+//
+//  CategoryListItemViewData.swift
+//  TodoListApp
+//
+//  Created by Pranav Patil on 08/01/24.
+//
+
+import Foundation
+
+class CategoryListItemViewData {
+
+    var name: String?
+    var shouldDelete: Bool
+
+    init(name: String?, shouldDelete: Bool = false) {
+        self.name = name
+        self.shouldDelete = shouldDelete
+    }
+
+}

--- a/TodoListApp/TodoList/ViewData/TodoListItemViewData.swift
+++ b/TodoListApp/TodoList/ViewData/TodoListItemViewData.swift
@@ -11,10 +11,10 @@ class TodoListItemViewData {
 
     var isCompleted: Bool
     var title: String?
-    var parentCategory: CategoryListItemModel?
+    var parentCategory: CategoryListItemViewData?
     var shouldDelete: Bool
 
-    init(isCompleted: Bool, title: String?, parentCategory: CategoryListItemModel?, shouldDelete: Bool = false) {
+    init(isCompleted: Bool, title: String?, parentCategory: CategoryListItemViewData?, shouldDelete: Bool = false) {
         self.isCompleted = isCompleted
         self.title = title
         self.parentCategory = parentCategory

--- a/TodoListApp/TodoList/ViewData/ViewDataTransformer.swift
+++ b/TodoListApp/TodoList/ViewData/ViewDataTransformer.swift
@@ -14,8 +14,14 @@ class ViewDataTransformer {
             return TodoListItemViewData(
                 isCompleted: model.isCompleted,
                 title: model.title,
-                parentCategory: model.parentCategory,
+                parentCategory: CategoryListItemViewData(name: model.parentCategory?.name),
                 shouldDelete: false)
+        }
+    }
+
+    static func getCategoryListItemViewDatas(from models: [CategoryListItemModel]) -> [CategoryListItemViewData] {
+        return models.map { model in
+            return CategoryListItemViewData(name: model.name)
         }
     }
 


### PR DESCRIPTION
**[TLA-12](https://pranavpatil2898.atlassian.net/browse/TLA-12): Add support to delete items in category screen**
- Added bulk action delete support in category list screen.
- Refactored `CategoryListViewController` to use `CategoryListItemViewData` instead of `CategoryListItemModel`.
- Created `CategoryListDataHandler` and `CategoryListItemViewData` to handle data in category list screen.
- Renamed `LocalDataHandler` to `TodoListDataHandler`. Now `TodoListDataHandler` handles data related to todo list screen.
- Updated view data, view controller, other category list related classes to use `CategoryListItemViewData` instead of using `CategoryListItemModel` to display and handle data.
- Now `CategoryListItemModel` will only be used at the data layer i.e. data handler classes.


**Demo video**

https://github.com/Pranav-Patil-India/TodoListApp/assets/112779087/6b45a2b2-50a3-409e-a755-d4f2e6ba884b


https://github.com/Pranav-Patil-India/TodoListApp/assets/112779087/811b68cb-e280-4b0b-ad42-a36f03ffc973

[category_screen_working.mov.zip](https://github.com/Pranav-Patil-India/TodoListApp/files/14080968/category_screen_working.mov.zip)

[TLA-12]: https://pranavpatil2898.atlassian.net/browse/TLA-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ